### PR TITLE
Fixed: Race condition on dispose that triggers AccessViolationException and kills the process

### DIFF
--- a/Nickvision.MPVSharp/Client.cs
+++ b/Nickvision.MPVSharp/Client.cs
@@ -12,6 +12,7 @@ namespace Nickvision.MPVSharp;
 public class Client : MPVClient, IDisposable
 {
     private bool _disposed;
+    private bool _isDisposing;
 
     public event EventHandler<LogMessageReceivedEventArgs>? LogMessageReceived;
     public event EventHandler<GetPropertyReplyReceivedEventArgs>? GetPropertyReplyReceived;
@@ -64,6 +65,7 @@ public class Client : MPVClient, IDisposable
         }
         if (disposing)
         {
+            _isDisposing = true;
             Destroy();
         }
         _disposed = true;
@@ -144,7 +146,7 @@ public class Client : MPVClient, IDisposable
     /// </summary>
     private void HandleEvents()
     {
-        while (!_disposed)
+        while (!_disposed && !_isDisposing)
         {
             var clientEvent = WaitEvent(0);
             switch (clientEvent.Id)


### PR DESCRIPTION
Only happens rarely, but there is a race condition on dispose that can trigger an AccessViolationException and kill the process.  If the event process loop loops back around after Destroy() is called, but before the _disposed flag is set then the subsequent call to mpv_wait_event will kill the process